### PR TITLE
Test pagination code

### DIFF
--- a/client.go
+++ b/client.go
@@ -363,6 +363,9 @@ var maxItems = 500
 // modification of items.
 // Unfortunately, the protection does not cover any requests from other clients/processes/systems.
 func (client *Client) Get(path string, mods ...func(*Req)) (Res, error) {
+	// This channel operation will wait for any writers to complete first.
+	// Improvement idea: optimistic GET without any waiting. But then if it returns 500 items,
+	// throw its result away, wait for lock, restart with pagination?
 	client.readers <- +1
 	defer func() { client.readers <- -1 }()
 

--- a/client_pages_test.go
+++ b/client_pages_test.go
@@ -1,0 +1,156 @@
+package cc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+// TestClientGet_PagesBasic is like TestClientGet, but with basic pagination.
+func TestClientGet_PagesBasic(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+	var err error
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	gock.New(testURL).Get("/url").
+		Reply(200).
+		BodyString(`{"response":["1","2","3"]}`)
+	gock.New(testURL).Get("/url").MatchParam("offset", "4").
+		Reply(200).
+		BodyString(`{"response":["4","5","6"]}`)
+	gock.New(testURL).Get("/url").MatchParam("offset", "7").
+		Reply(200).
+		BodyString(`{"response":["7","8"]}`)
+
+	res, err := client.Get("/url")
+	assert.NoError(t, err)
+	assert.Equal(t, `{"response":["1","2","3","4","5","6","7","8"]}`, res.Raw)
+}
+
+// TestClientGet_PagesExplicit is like TestClientGet_PagesBasic, but with explicit limit parameter.
+func TestClientGet_PagesExplicit(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	// For now parameter must be equal to the max limit.
+	gock.New(testURL).Get("/url").MatchParam("limit", "3").
+		Reply(200).
+		BodyString(`{"response":[1,2,3]}`)
+	gock.New(testURL).Get("/url").MatchParam("limit", "3").MatchParam("offset", "4").
+		Reply(200).
+		BodyString(`{"response":[4]}`)
+
+	res, err := client.Get("/url?limit=3")
+	assert.NoError(t, err)
+	assert.Equal(t, `{"response":[1,2,3,4]}`, res.Raw)
+}
+
+// TestClientGet_PagesWithExtras is like TestClientGet_PagesBasic and ensures that the extra attributes from the last
+// page prevail.
+func TestClientGet_PagesWithExtras(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	gock.New(testURL).Get("/url").
+		Reply(200).
+		BodyString(`{"response":[1,2,3],"extra":42}`)
+	gock.New(testURL).Get("/url").MatchParam("offset", "4").
+		Reply(200).
+		BodyString(`{"response":[4],"extra":"x"}`)
+
+	res, err := client.Get("/url")
+	assert.NoError(t, err)
+	assert.Equal(t, `{"response":[1,2,3,4],"extra":"x"}`, res.Raw)
+}
+
+// TestClientGet_FirstNonArray tests the Client.Get against non-array attribute "response".
+func TestClientGet_FirstNonArray(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+
+	gock.New(testURL).Get("/url").
+		Reply(200).
+		BodyString(`{"response":"a string"}`)
+
+	res, err := client.Get("/url")
+	assert.NoError(t, err)
+	assert.Equal(t, "a string", res.Get("response").String())
+}
+
+// TestClientGet_ArrayVaries tests the Client.Get against a corner case when response varies between
+// array and non-array.
+func TestClientGet_ArrayVaries(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+	var err error
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	gock.New(testURL).Get("/url").
+		Reply(200).
+		BodyString(`{"response":["1","2","3"]}`)
+	gock.New(testURL).Get("/url").MatchParam("offset", "4").
+		Reply(200).
+		BodyString(`{"response":"a string"}`)
+
+	_, err = client.Get("/url")
+	assert.Error(t, err)
+}
+
+// TestClientGet_LastPageEmpty is like TestClientGet_PagesBasic, but when the last page is empty.
+func TestClientGet_LastPageEmpty(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	gock.New(testURL).Get("/url").
+		Reply(200).
+		BodyString(`{"response":["1","2","3"]}`)
+
+	gock.New(testURL).Get("/url").MatchParam("offset", "4").
+		Reply(200).
+		BodyString(`{"response":[]}`)
+
+	res, err := client.Get("/url")
+	assert.NoError(t, err)
+	assert.Equal(t, `{"response":["1","2","3"]}`, res.Raw)
+}
+
+// TestClientGet_PageTooBig is like TestClientGet_PagesBasic, but when too many items are returned.
+// Let's assume that just means the path does not know about pagination.
+func TestClientGet_PageTooBig(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	gock.New(testURL).Get("/url").
+		Reply(200).
+		BodyString(`{"response":["1","2","3","4"]}`)
+	gock.New(testURL).Get("/url").MatchParam("offset", ".*").
+		Reply(400) // The important part: avoid further queries.
+
+	res, err := client.Get("/url")
+	assert.NoError(t, err)
+	assert.Equal(t, `{"response":["1","2","3","4"]}`, res.Raw)
+}

--- a/client_pages_test.go
+++ b/client_pages_test.go
@@ -1,6 +1,7 @@
 package cc
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,4 +154,153 @@ func TestClientGet_PageTooBig(t *testing.T) {
 	res, err := client.Get("/url")
 	assert.NoError(t, err)
 	assert.Equal(t, `{"response":["1","2","3","4"]}`, res.Raw)
+}
+
+// TestClientGet_Concurrent test against a concurrent Post/Put/Delete modifying how data
+// is divided into the pages. As Get glues the desired pages, the modifying methods shouldn't
+// interrupt.
+func TestClientGet_Concurrent(t *testing.T) {
+	defer gock.Off()
+	client := authenticatedTestClient()
+
+	// For pagination tests to be readable, we use dummy page size of 3 instead of 500.
+	// Since we are changing a package-level var, this test cannot be run on t.Parallel().
+	maxItems = 3
+
+	recorder := make(chan string)
+	cleanup := make(chan bool)
+
+	// Stochastic test: the more, the merrier.
+	const (
+		posters  = 10
+		putters  = 10
+		deleters = 10
+		taskers  = 10
+		getters  = 1
+	)
+
+	gock.New(testURL).Post("/url/insert").
+		Times(posters).
+		Reply(200).
+		Map(func(resp *http.Response) *http.Response {
+			recorder <- "post"
+			return resp
+		})
+
+	for i := 0; i < posters; i++ {
+		go func() {
+			_, err := client.Post("/url/insert", "{}")
+			assert.NoError(t, err)
+			cleanup <- true
+		}()
+	}
+
+	gock.New(testURL).Put("/url").MatchParam("id", "5").
+		Times(putters).
+		Reply(200).
+		Map(func(resp *http.Response) *http.Response {
+			recorder <- "put"
+			return resp
+		})
+
+	for i := 0; i < putters; i++ {
+		go func() {
+			_, err := client.Put("/url?id=5", "{}")
+			assert.NoError(t, err)
+			cleanup <- true
+		}()
+	}
+
+	gock.New(testURL).Delete("/url/5").
+		Times(deleters).
+		Reply(200).
+		Map(func(resp *http.Response) *http.Response {
+			recorder <- "delete"
+			return resp
+		})
+
+	for i := 0; i < deleters; i++ {
+		go func() {
+			_, err := client.Delete("/url/5")
+			assert.NoError(t, err)
+			cleanup <- true
+		}()
+	}
+
+	gock.New(testURL).Post("/taskable").
+		Times(taskers).
+		Reply(200).
+		BodyString(`{"response": {"taskId": "123"}}`)
+	gock.New(testURL).Get("/api/v1/task/123").
+		Times(taskers).
+		Reply(200).
+		BodyString(`{"response": {"endTime": "1", "isError": false}}`).
+		Map(func(resp *http.Response) *http.Response {
+			recorder <- "task"
+			return resp
+		})
+
+	for i := 0; i < taskers; i++ {
+		go func() {
+			_, err := client.Post("/taskable", "{}")
+			assert.NoError(t, err)
+			cleanup <- true
+		}()
+	}
+
+	// GET that glues 3 pages
+	go func() {
+		e := struct{}{}
+		gock.New(testURL).Get("/url").
+			Reply(200).
+			JSON(map[string]any{
+				"response": []any{e, e, e},
+			}).
+			Map(func(resp *http.Response) *http.Response {
+				recorder <- "get"
+				return resp
+			})
+		gock.New(testURL).Get("/url").MatchParam("offset", "4").
+			Reply(200).
+			JSON(map[string]any{
+				"response": []any{e, e, e},
+			}).
+			Map(func(resp *http.Response) *http.Response {
+				recorder <- "get"
+				return resp
+			})
+		gock.New(testURL).Get("/url").MatchParam("offset", "7").
+			Reply(200).
+			JSON(map[string]any{
+				"response": []any{e, e},
+			}).
+			Map(func(resp *http.Response) *http.Response {
+				recorder <- "get"
+				return resp
+			})
+		res, err := client.Get("/url")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"response":[{},{},{},{},{},{},{},{}]}`+"\n", res.Raw)
+		cleanup <- true
+	}()
+
+	got := ""
+	// Serialize writing the result, all the requests wait their turn.
+	// Record the sequence of events.
+	go func() {
+		for v := range recorder {
+			got = got + "," + v
+		}
+		cleanup <- true
+	}()
+
+	// Do not leak goroutines; do not leak t.Error calls made from inside goroutines.
+	for i := 0; i < getters+posters+putters+deleters+taskers; i++ {
+		<-cleanup
+	}
+
+	close(recorder)
+	<-cleanup // and the serializer itself
+
+	assert.Contains(t, got, "get,get,get")
 }

--- a/client_pages_test.go
+++ b/client_pages_test.go
@@ -78,20 +78,6 @@ func TestClientGet_PagesWithExtras(t *testing.T) {
 	assert.Equal(t, `{"response":[1,2,3,4],"extra":"x"}`, res.Raw)
 }
 
-// TestClientGet_FirstNonArray tests the Client.Get against non-array attribute "response".
-func TestClientGet_FirstNonArray(t *testing.T) {
-	defer gock.Off()
-	client := authenticatedTestClient()
-
-	gock.New(testURL).Get("/url").
-		Reply(200).
-		BodyString(`{"response":"a string"}`)
-
-	res, err := client.Get("/url")
-	assert.NoError(t, err)
-	assert.Equal(t, "a string", res.Get("response").String())
-}
-
 // TestClientGet_ArrayVaries tests the Client.Get against a corner case when response varies between
 // array and non-array.
 func TestClientGet_ArrayVaries(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -41,7 +41,7 @@ func TestNewClient(t *testing.T) {
 	assert.Equal(t, client.HttpClient.Timeout, 120*time.Second)
 }
 
-// TestClientLogin tests the Client::Login method.
+// TestClientLogin tests the Client.Login method.
 func TestClientLogin(t *testing.T) {
 	defer gock.Off()
 	client := testClient()
@@ -59,7 +59,7 @@ func TestClientLogin(t *testing.T) {
 	assert.Error(t, client.Login())
 }
 
-// TestClientGet tests the Client::Get method.
+// TestClientGet tests the Client.Get method.
 func TestClientGet(t *testing.T) {
 	defer gock.Off()
 	client := authenticatedTestClient()
@@ -92,7 +92,7 @@ func TestClientGet(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestClientDeleteDn tests the Client::Delete method.
+// TestClientDelete tests the Client.Delete method.
 func TestClientDelete(t *testing.T) {
 	defer gock.Off()
 	client := authenticatedTestClient()
@@ -112,7 +112,7 @@ func TestClientDelete(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestClientPost tests the Client::Post method.
+// TestClientPost tests the Client.Post method.
 func TestClientPost(t *testing.T) {
 	defer gock.Off()
 	client := authenticatedTestClient()
@@ -146,7 +146,7 @@ func TestClientPost(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestClientPost tests the Client::Post method.
+// TestClientPut tests the Client.Put method.
 func TestClientPut(t *testing.T) {
 	defer gock.Off()
 	client := authenticatedTestClient()
@@ -180,7 +180,7 @@ func TestClientPut(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestClientPost tests the Client::WaitTask method.
+// TestClientWaitTask tests the Client.WaitTask method.
 func TestClientWaitTask(t *testing.T) {
 	defer gock.Off()
 	client := authenticatedTestClient()

--- a/client_test.go
+++ b/client_test.go
@@ -66,9 +66,10 @@ func TestClientGet(t *testing.T) {
 	var err error
 
 	// Success
-	gock.New(testURL).Get("/url").Reply(200)
-	_, err = client.Get("/url")
+	gock.New(testURL).Get("/url").Reply(200).BodyString(`{"response":"a string"}`)
+	res, err := client.Get("/url")
 	assert.NoError(t, err)
+	assert.Equal(t, "a string", res.Get("response").String())
 
 	// HTTP error
 	gock.New(testURL).Get("/url").ReplyError(errors.New("fail"))

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/netascode/go-catalystcenter
 go 1.19
 
 require (
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.17.1
 	github.com/tidwall/sjson v1.2.5
 	gopkg.in/h2non/gock.v1 v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
 github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
Test pagination code without concurrency.

Test pagination code with concurrency (GETs do not happen when POST/PUT/DELETE is running, and vice versa).

No changes to functionality except comments.