### PR TITLE
added NoWait to indicates whether to wait for the task or not

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,6 +174,7 @@ func (client Client) NewReq(method, uri string, body io.Reader, mods ...func(*Re
 		LogPayload:       true,
 		Synchronous:      true,
 		MaxAsyncWaitTime: client.DefaultMaxAsyncWaitTime,
+		NoWait:           false,
 	}
 	for _, mod := range mods {
 		mod(&req)
@@ -274,7 +275,7 @@ func (client *Client) Do(req Req) (Res, error) {
 		}
 	}
 
-	if req.Synchronous && req.HttpReq.Method != "GET" && req.HttpReq.Method != "" {
+	if !req.NoWait && req.Synchronous && req.HttpReq.Method != "GET" && req.HttpReq.Method != "" {
 		return client.WaitTask(&req, &res)
 	}
 

--- a/req.go
+++ b/req.go
@@ -54,6 +54,8 @@ type Req struct {
 	Synchronous bool
 	// MaxAsyncWaitTime is the maximum time to wait for an asynchronous operation.
 	MaxAsyncWaitTime int
+	// NoWait indicates whether to wait for the task or not. If True, the WaitTask function will not be executed.
+	NoWait bool
 }
 
 // NoLogPayload prevents logging of payloads.

--- a/req.go
+++ b/req.go
@@ -77,3 +77,8 @@ func MaxAsyncWaitTime(seconds int) func(*Req) {
 		req.MaxAsyncWaitTime = seconds
 	}
 }
+
+// NoWait operation
+func NoWait(req *Req) {
+	req.NoWait = true
+}


### PR DESCRIPTION
In 2.3.7.6 DNAC version there is new API for LAN Automation Start. This new V2 API dna/intent/api/v2/lan-automation on POST is behaving differently than LAN Automation Start V1.
In V1  response was as follows: 
```
 {"response":{"message":"LAN Automation Session Started. For more info check LAN Automation Status.","id":"0191465c-8240-7fff-9191-81882a87cac1"},"version":"1.0"}
```
so we could extract id directly from response, but in V2 response looks like this:
```
{"response":{"taskId":"0191462e-5882-7e01-a614-feeec69bb17c","url":"/api/v1/task/0191462e-5882-7e01-a614-feeec69bb17c"},"version":"1.0"}
```
This was done to ensures consistent return for async APIs across CatC, but since we are getting taskId in response, WaitTask function is checking status of this task and waits for that to finish. But since LAN automation can run for a long time I added NoWait flag which executes client.WaitTask(&req, &res) only if NoWait is false if its true then this WaitTask func is not executed.

This change allows to retrieve id (taskId) from POST response in terraform provider using also flag no_wait and adding appropriate code to resource.go template file utilizing this NoWait flag.